### PR TITLE
Build docker image with sbt

### DIFF
--- a/docker/application.conf
+++ b/docker/application.conf
@@ -1,0 +1,62 @@
+# This is the main configuration file for the application.
+# ~~~~~
+application.windowTitle = theGardener
+application.title = "In our documentation we trust."
+application.logoSrc = "assets/images/logo-white.png"
+application.faviconSrc = "assets/images/favicon.png"
+application.baseUrl = "http://localhost:9000"
+
+color.main="#1F7079"
+
+# Filters
+play.http.filters=filters.Filters
+
+# Secret key
+# ~~~~~
+# The secret key is used to secure cryptographics functions.
+# If you deploy your application to several instances be sure to use the same key!
+play.http.secret.key = "<Mf_T2OmqeZD1d6AtDjYtdeN33hJjo]OtgJVZRwZGckD28wn3r3UtKP6ZQMKXPw`"
+
+# The application languages
+# ~~~~~
+play.i18n.langs = ["en"]
+
+# Disable filters for Swagger
+play.filters.disabled += "play.filters.headers.SecurityHeadersFilter"
+play.filters.disabled += "play.filters.csrf.CSRFFilter"
+# Swagger
+play.modules.enabled += "play.modules.swagger.SwaggerModule"
+
+api.version = "1.0"
+
+# Database configuration
+# ~~~~~ 
+# You can declare as many datasources as you want.
+# By convention, the default datasource is named `default`
+#
+db.default.driver = org.h2.Driver
+db.default.url = "jdbc:h2:/data/thegardener;AUTO_SERVER=TRUE"
+db.default.username = sa
+db.default.password = ""
+play.evolutions.autoApply = true
+
+#
+# You can expose this datasource via JNDI if needed (Useful for JPA)
+# db.default.jndiName=DefaultDS
+
+projects.root.directory = "/git-data/"
+projects.synchronize.interval = 86400
+projects.synchronize.initial.delay = 10
+
+projects.synchronize.from.remote.enabled = true
+
+documentation.meta.file = "thegardener.json"
+
+replica.url= "http://localhost:9009"
+
+play.server.http.idleTimeout = 1200s
+play.server.akka.requestTimeout = 1200s
+
+akka.http.server.idle-timeout = 1200s
+akka.http.server.request-timeout = 1200s
+

--- a/documentation/guides/contribute.md
+++ b/documentation/guides/contribute.md
@@ -29,37 +29,216 @@ Join us on [Discord](https://discordapp.com/channels/417704230531366923/41770423
 
 ## Want to develop  
 
+### Requirements 
+
+You will need following tools to develop on theGardener project:
+
+| Requirement       |     Version     |      Purpose     | 
+| :------------     | :-------------: | :------------ |
+| git               |     >= 2.20.0   | get the sources |
+| java              |     >= 1.8.0    | run sbt and scala as theGardener run over Play/Scala  |
+| sbt               |     > 1.3       | get Scala dependencies and run the Play server  |
+| npm               |      >= 6.5.0   | get Angular dependencies  |
+| Angular CLI (ng)  |      >= 7.3.8   | angular command line to serve the front end  |
+| MySQL             |     ~ 8.0.?     | store and serve data |
+
+Note that you can absolutely use a MySQL instance running inside Docker if you don't want to setup a MySQL instance on
+your machine.
 
 ### Install a dev environment
 
-TODO....
+#### Sources
+
+Get sources:
+```
+git clone git@github.com:KelkooGroup/theGardener.git theGardener
+```
+
+#### Data
+
+Create an empty directory _theGardener_git_data_ to store projects sources.
+
+#### Init dababase
+
+Create a database on mysql called _thegardener_.
+
+#### Application.conf
+
+Create a file _local-config/application.local.conf_ in theGardener sources to be able to store data in the local
+directory and in the local database:
+```
+include "application.conf"
+
+db.default.driver=com.mysql.cj.jdbc.Driver
+db.default.url="jdbc:mysql://localhost:3306/thegardener?autoReconnect=true&useSSL=false&characterEncoding=utf8&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC"
+db.default.username=root
+db.default.password="somePassword"
+
+projects.root.directory = "theGardener_git_data/"
+projects.synchronize.interval = 86400
+projects.synchronize.initial.delay = 10
+```
+
+#### Start the backend to apply database changes
+
+Run the backend
+```
+sbt "~run -Dconfig.file=local-conf/application.local.conf"
+```
+
+Access to the Swagger doc : 
+```
+http://localhost:9000/api/docs
+```
+
+This will create the tables in the database
+```
+mysql> use thegardener ;
+Database changed
+mysql> show tables ;
++-----------------------+
+| Tables_in_thegardener |
++-----------------------+
+| branch                |
+| feature               |
+| feature_tag           |
+| hierarchyNode         |
+| play_evolutions       |
+| project               |
+| project_hierarchyNode |
+| scenario              |
+| scenario_tag          |
+| tag                   |
++-----------------------+
+10 rows in set (0.00 sec)
+```
+
+Stop the backend by killing the _sbt_ process.
+
+#### Start 
+
+Start the backend:
+```
+sbt "~run -Dconfig.file=local-conf/application.local.conf"
+```
+
+Start the frontend:
+```
+cd frontend
+ng serve
+```
+
+##### Use the application 
+
+Open [http://localhost:4200](http://localhost:4200)
+
+![image](https://user-images.githubusercontent.com/5529106/59674697-1f85f100-91c4-11e9-82dd-d52b8acd7a74.png)
+
+##### Use the backend
+
+Open [http://localhost:9000/api/docs](http://localhost:9000/api/docs)
+
+![image](https://user-images.githubusercontent.com/5529106/59674484-a71f3000-91c3-11e9-9d94-2d57400bf45f.png)
 
 ### Development on Back
 
-
 TODO....
 
-Before push, 
+Before push:
 
 ```
 sbt test
 sbt scapegoat
 ```
 
-
 ### Development on Front
 
 The front is under _frontend_ directory.
 
-
 TODO....
 
-Before push, 
+Get Angular dependencies: 
+```
+cd frontend
+npm install
+```
+
+Before push:
 
 ```
 ng test
 ng lint --fix
 ```
+
+
+### Build and push a Docker image
+
+As a theGardener developer you can build and push a Docker image of theGardener with
+following commands.
+
+#### Pre-requisites
+
+_Please notet that we aim to smooth the build experience with a single command in the future._
+
+As the frontend Angular build is not included in the sbt lifecycle for now, you have to run following
+commands before building a Docker image:
+
+```
+cd frontend
+npm install
+npm run build-prod
+rm -rf ../public/dist
+cp -r dist ../public/dist
+cd ..
+```
+
+This will build the Angular app and copy generated files in the `public` folder included in the 
+backend build.
+
+Then, run:
+
+```
+sbt clean stage
+```
+
+#### Build an image
+
+```
+sbt docker
+```
+
+This will build an image called `kelkoogroup/thegardener` with 2 tags: `latest` and
+`X.Y.Z` where `X.Y.Z` is the version defined in the `version.sbt` file.
+
+To build the image, we use the [sbt-docker](https://github.com/marcuslonnberg/sbt-docker)
+plugin which allows the Docker build to be part of the sbt lifecycle. The Dockerfile is
+defined in the `build.sbt` file within the following section:
+```
+dockerfile in docker := {
+    new Dockerfile {
+        ...
+    }
+}
+```
+
+#### Push an image
+
+To be able to push, you need a Docker account allowed on the _kelkoogroup_ Docker Hub
+organization and you need to login first with following command:
+
+```
+docker login
+```
+
+Then you can use one of those commands:
+
+```
+sbt dockerPush # If image already built
+sbt dockerBuildAndPush # To build and push in one command
+```
+
+Note that pushing an image to Docker Hub can take few minutes.
+
 
 
 

--- a/documentation/guides/install.md
+++ b/documentation/guides/install.md
@@ -54,6 +54,9 @@ curl -X POST "http://localhost:9000/api/projects/theGardener/hierarchy/.01." \
 
 curl -X POST "http://localhost:9000/api/projects/theGardener/synchronize" \
     -H  "accept: application/json"
+    
+curl -X POST "http://localhost:9000/api/admin/menu/refreshFromDatabase" -H  "accept: application/json"
+    
 ```
 
 ### Customize the configuration
@@ -63,7 +66,12 @@ configuration file, let's say `/tmp/application-custom.conf` which can look like
 ```
 include "application.conf"
 
-projects.synchronize.interval = 3600
+application.windowTitle = "Title in the browser tab"
+application.title = "Title in the page under the logo"
+application.logoSrc = "assets/images/logo-white.png"
+application.faviconSrc = "assets/images/favicon.png"
+color.main="#2b709a"
+
 ```
 
 This will override default configuration defined in `application.conf` with your custom
@@ -79,7 +87,7 @@ docker run --name thegardener \
     -Dconfig.file=/app-conf/application-custom.conf
 ```
 
-Puting your file in the `/app-conf` directory allows you to include the default configuration
+Putting your file in the `/app-conf` directory allows you to include the default configuration
 file but you can also put it in any place you want.
 
 ### Persist Git data

--- a/documentation/guides/thegardener.json
+++ b/documentation/guides/thegardener.json
@@ -1,6 +1,5 @@
 {
-  "directory" :
-  {
+  "directory": {
     "label": "theGuides",
     "description": "How do we interact with theGardener ?",
     "pages": [
@@ -12,8 +11,7 @@
       "read",
       "contribute"
     ],
-    "children" :[
-
+    "children": [
     ]
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,6 @@ addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("org.jmotor.sbt" % "sbt-dependency-updates" % "1.2.1")
 
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+
 evictionWarningOptions in update := EvictionWarningOptions.empty

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.12.0"


### PR DESCRIPTION
Fixes #431 

This MR contains:
- Add Docker image build and push as sbt tasks (see documentation): `sbt docker`, `sbt dockerPush`.
- Move "Install" doc to "Contribute" doc which seems more appropriate (manual build and run)
- Create "Install" doc with Docker guidelines

See DockerHub: https://hub.docker.com/r/kelkoogroup/thegardener

I also created a dedicated [theGardener-template](https://github.com/KelkooGroup/theGardener-template) project to demonstrate the project (related to #485).

Notes:
- I didn't use the sbt-jib plugin, I didn't succeed to use it
- the Docker build is not automated, I guess we could automate it with Github Actions in some way
- I had to rollback some dependencies to ensure Swagger works (Jackson version conflict, I didn't want to spend time on it)

Pending before we can merge this:
- [ ] Review documentation