### PR TITLE
Avoid duplicated scenario names

### DIFF
--- a/test/features/administration/hierarchy/link_projects_to_hierarchy.feature
+++ b/test/features/administration/hierarchy/link_projects_to_hierarchy.feature
@@ -76,7 +76,7 @@ Feature: Link a project to the hierarchy
       | suggestionsWS | .02.        |
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: Get hierarchy nodes related to a project
+  Scenario: Get hierarchy nodes related to a project, case 1
     Given the links between hierarchy nodes are
       | projectId     | hierarchyId |
       | suggestionsWS | .01.01.01.  |
@@ -110,7 +110,7 @@ Feature: Link a project to the hierarchy
   """
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: Get hierarchy nodes related to a project
+  Scenario: Get hierarchy nodes related to a project, case 2
     Given the links between hierarchy nodes are
       | projectId     | hierarchyId |
       | suggestionsWS | .01.01.01.  |

--- a/test/features/administration/projects/register_a_project.feature
+++ b/test/features/administration/projects/register_a_project.feature
@@ -19,7 +19,7 @@ Feature: Register a project
       | suggestionsWS | Suggestions WebServices | git@gitlab.corp.kelkoo.net:library/suggestionsWS.git | master       | test/features    |
 
   @level_2_technical_details @nominal_case @valid @register_project
-  Scenario: setup a project
+  Scenario: setup a project, details
     Given no project settings are setup in theGardener
     When I perform a "POST" on following URL "/api/projects" with json body
         """

--- a/test/features/documentation/page/show_a_page.feature
+++ b/test/features/documentation/page/show_a_page.feature
@@ -25,7 +25,7 @@ Feature: Generate a documentation page
 
     # TODO Make sure to have an index on the column "path"
   @level_2_technical_details @nominal_case @valid
-  Scenario: generate a documentation page
+  Scenario: generate a documentation page, case 1
     Given we have those directories in the database
       | id | name        | label         | description             | order | relativePath  | path                               | branchId |
       | 1  | root        | SuggestionsWS | Suggestions WebServices | 0     | /             | suggestionsWS>master>/             | 1        |
@@ -61,7 +61,7 @@ Feature: Generate a documentation page
 """
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: generate a documentation page
+  Scenario: generate a documentation page, case 2
     Given we have those directories in the database
       | id | name | label         | description             | order | relativePath | path                   | branchId |
       | 1  | root | SuggestionsWS | Suggestions WebServices | 0     | /            | suggestionsWS>master>/ | 1        |

--- a/test/features/documentation/page/show_a_page_without_branch_name_in_path.feature
+++ b/test/features/documentation/page/show_a_page_without_branch_name_in_path.feature
@@ -18,7 +18,7 @@ Feature: Generate a documentation page without branch in path
 
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: generate a documentation page without branch in path
+  Scenario: generate a documentation page without branch in path, case 1
     Given we have those branches in the database
       | id | name   | isStable | projectId     |
       | 1  | master | true     | suggestionsWS |
@@ -57,7 +57,7 @@ Feature: Generate a documentation page without branch in path
 """
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: generate a documentation page without branch in path
+  Scenario: generate a documentation page without branch in path, case 2
     Given we have those branches in the database
       | id | name       | isStable | projectId     |
       | 1  | master     | true     | suggestionsWS |

--- a/test/features/navigation/provide_menu.feature
+++ b/test/features/navigation/provide_menu.feature
@@ -536,7 +536,7 @@ Feature: Provide menu
 """
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: provide pages of a directory
+  Scenario: provide pages of a directory, case 1
     Given the hierarchy nodes are
       | id         | slugName   | name                 | childrenLabel | childLabel   |
       | .          | root       | Hierarchy root       | Views         | View         |
@@ -611,7 +611,7 @@ Feature: Provide menu
     """
 
   @level_2_technical_details @nominal_case @valid
-  Scenario: provide pages of a directory
+  Scenario: provide pages of a directory, case 2
     Given the hierarchy nodes are
       | id         | slugName   | name                 | childrenLabel | childLabel   |
       | .          | root       | Hierarchy root       | Views         | View         |


### PR DESCRIPTION
This PR aims to prevent errors in BDD tests not to be reported.

See https://github.com/sbt/junit-interface/issues/84

For some scenarios I named them "case 1", "case 2". I don't really like that. If anyone who knows better the scenarios can find an appropriate name, it would be better :) Maybe @lecunm?