### PR TITLE
Better handling of invalid project when requesting a page

### DIFF
--- a/test/features/documentation/page/show_a_page_error_cases.feature
+++ b/test/features/documentation/page/show_a_page_error_cases.feature
@@ -1,0 +1,30 @@
+Feature: Generate a documentation page, error cases
+
+  Background:
+    Given the database is empty
+    And the cache is empty
+    And No project is checkout
+    And the remote projects are empty
+    And the hierarchy nodes are
+      | id   | slugName   | name              | childrenLabel | childLabel |
+      | .    | root       | Hierarchy root    | Views         | View       |
+      | .01. | suggestion | Suggestion system | Projects      | Project    |
+    And we have the following projects
+      | id            | name                    | repositoryUrl                                         | stableBranch | featuresRootPath | documentationRootPath |
+      | suggestionsWS | Suggestions WebServices | target/remote/data/GetFeatures/library/suggestionsWS/ | master       | test/features    | doc                   |
+    And the links between hierarchy nodes are
+      | projectId     | hierarchyId |
+      | suggestionsWS | .01.        |
+    And we have those branches in the database
+      | id | name   | isStable | projectId     |
+      | 1  | master | true     | suggestionsWS |
+
+
+  @level_2_technical_details @error_case @valid
+  Scenario: Path doesn't match a project
+    When I perform a "GET" on following URL "/api/pages?path=badProject>master>/context"
+    Then I get a response with status "404"
+    And I get the following response body
+"""
+No Page badProject>master>/context
+"""


### PR DESCRIPTION
This PR aims to solve the `FIXME` I introduced in a previous PR.

In `computePageFromPath()` method, if we can't find an existing project ID from the path, we would still try to do some useless computations:

```scala
val pathWithBranch = projectOpt.map(...).getOrElse(s"Error while computing Page for the path $path")
// work with pathWithBranch
```

Now, if there is no project, we just exit the method (actually we continue to `map` over the option instead of having a `getOrElse` at this line).