### PR TITLE
fix: enable back compilation flags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,9 @@ scalacOptions ++= {
   if (insideCI.value) Seq("-Wconf:any:error", "-Xfatal-warnings")
   else Seq("-Wconf:any:warning")
 }
-scalacOptions += "-Wconf:src=target/.*:silent" // Ignore everything in generated files (from Play routes)
-
+// Ignore everything in generated files (from Play routes)
+// See https://github.com/scala/bug/issues/12631 for context of why rootdir is necessary
+scalacOptions ++= Seq("-rootdir", ".", "-Wconf:src=target/.*:silent")
 
 // Add option to enable anorm stack traces
 javaOptions += "-Dscala.control.noTraceSuppression=true"

--- a/test/services/SearchServiceTest.scala
+++ b/test/services/SearchServiceTest.scala
@@ -59,7 +59,6 @@ class SearchServiceTest extends AnyWordSpec with Matchers with BeforeAndAfter wi
       items(2).page.id must equal("id4")
     }
 
-
     "insert or update in lucene" in {
       var result = searchService.searchForPage("Superstore").items
 
@@ -67,9 +66,8 @@ class SearchServiceTest extends AnyWordSpec with Matchers with BeforeAndAfter wi
       result.head.page.id must equal("id2")
       result.head.page.description must equal("page two")
 
-
-      for(pageNumber <- 1 to 10){
-        pageIndex.insertOrUpdateDocument(PageIndexDocument("id2", "hierarchy2", "path2", "breadcrum2", "branch2", "project2", "Superstore", s"page ${pageNumber}", ""))
+      for (pageNumber <- 1 to 10) {
+        pageIndex.insertOrUpdateDocument(PageIndexDocument("id2", "hierarchy2", "path2", "breadcrum2", "branch2", "project2", "Superstore", s"page $pageNumber", ""))
       }
 
       result = searchService.searchForPage("Superstore").items
@@ -79,8 +77,6 @@ class SearchServiceTest extends AnyWordSpec with Matchers with BeforeAndAfter wi
       result.head.page.description must equal(s"page 10")
     }
 
-
   }
-
 
 }


### PR DESCRIPTION
Ensure a corner case of using `-Wconf:src=target/.*:silent` when in a absolute path containing `target` does not make compilation errors ignored (see https://github.com/scala/bug/issues/12631 for context).